### PR TITLE
Allow configurable network names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ with the /load command).  You're ready to go.
 
 Other than pmpassword and pmuser, other options include:
 
-- item nick-prefix
-- item nick-suffix
+- nick-prefix
+- nick-suffix
 
 Here you can customise how the nicks will appear in Xchat.  I set these this
 way:
@@ -49,7 +49,14 @@ way:
 Then nicks will show up like "[tye]" instead of just "tye".  This makes it
 easier for cut&paste for me.
 
-- item ignore_mode
+- network_name
+
+If your distro has changed the server name to something other than "freenode"
+you can specify it here. This is treated as a regex, which means that as long
+as "freenode" is part of the name, the default will work for you, but if you
+absolutely need to change it, it's configurable here.
+
+- ignore_mode
 
 If you have anyone being ignored, you can actually be told when you receive
 a message from them.  You can set this mode to C<brief> to get a notice

--- a/cbstream.pl
+++ b/cbstream.pl
@@ -69,6 +69,11 @@ Xchat::register($name, $version, 'CBStream re-writer');
     }
 }
 
+sub get_network_name
+{
+    get_conf('cbstream', 'network_name') || 'freenode';
+}
+
 # because hexchat reads $@ even when there is no error, we need to
 # ensure it gets blanked out.
 # ( see https://github.com/hexchat/hexchat/issues/2076 )
@@ -105,7 +110,7 @@ sub JoinCBStreamLogin
 {
     my $info = shift;
 
-    if (lc Xchat::get_info('network') eq 'freenode')
+    if (lc Xchat::get_info('network') =~ get_network_name)
     {
         if ($info->[1] eq '#cbstream-login')
         {
@@ -127,7 +132,7 @@ sub LeaveCBStreamLogin
     my $msg = shift;
     my $nth = shift;
 
-    if (lc Xchat::get_info('network') eq 'freenode')
+    if (lc Xchat::get_info('network') =~ get_network_name)
     {
         if ($msg->[0] =~ /^:cbstream!/ and
             $msg->[1] eq 'PRIVMSG' and
@@ -266,7 +271,7 @@ sub rewrite_cb
     my $msg = shift;
     my $nth = shift;
 
-    if (lc (Xchat::get_info('network')||'unknown') eq 'freenode')
+    if (lc (Xchat::get_info('network')||'unknown') =~ get_network_name)
     {
         #LOG(@$msg);
         if ($msg->[0] =~ /^:cbstream!/ and


### PR DESCRIPTION
Some distros use a different name from "freenode". Allow the user to
configure it.  We'll provide a default here, and use a regex so that
as long as "freenode" appears in the name (and not in the name of any
other network the user is connected to, I hope), the default should
Just Work (TM).

Fixes #1